### PR TITLE
Retry at least once when client receives a 401 from service

### DIFF
--- a/sand_test.go
+++ b/sand_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Sand", func() {
 
 	BeforeEach(func() {
 		client, _ = NewClient("i", "s", "u")
-		client.MaxRetry = 0
+		client.DefaultRetryCount = 0
 	})
 
 	Describe("#NewClient", func() {
@@ -73,7 +73,7 @@ var _ = Describe("Sand", func() {
 			Context("with service responding 401", func() {
 				BeforeEach(func() {
 					//2 retry should sleep two times: 1 + 2 = 3 seconds
-					client.MaxRetry = 2
+					client.DefaultRetryCount = 2
 				})
 				It("performs the retry", func() {
 					mockResponse := &http.Response{StatusCode: 401}
@@ -94,6 +94,7 @@ var _ = Describe("Sand", func() {
 					})
 					t2 := time.Now().Unix()
 					Expect(t2 - t1).To(BeNumerically(">=", 3))
+					Expect(t2 - t1).To(BeNumerically("<", 4))
 					Expect(resp.StatusCode).To(Equal(401))
 				})
 			})
@@ -101,7 +102,7 @@ var _ = Describe("Sand", func() {
 			Context("with service responding 502", func() {
 				BeforeEach(func() {
 					//3 retries should sleep 3 times: 1 + 2 + 4 = 7 seconds
-					client.MaxRetry = 3
+					client.DefaultRetryCount = 3
 				})
 				It("does not perform retry", func() {
 					mockResponse := &http.Response{StatusCode: 502}
@@ -121,7 +122,7 @@ var _ = Describe("Sand", func() {
 						return mockResponse, nil
 					})
 					t2 := time.Now().Unix()
-					Expect(t2 - t1).To(BeNumerically("<", 7))
+					Expect(t2 - t1).To(BeNumerically("<", 1))
 					Expect(resp.StatusCode).To(Equal(502))
 				})
 			})
@@ -129,7 +130,7 @@ var _ = Describe("Sand", func() {
 			Context("with calling function returning an error", func() {
 				BeforeEach(func() {
 					//3 retries would have taken 7 seconds
-					client.MaxRetry = 3
+					client.DefaultRetryCount = 3
 				})
 				It("returns the error without retry", func() {
 					mockResponse := &http.Response{StatusCode: 200}
@@ -185,43 +186,62 @@ var _ = Describe("Sand", func() {
 			})
 
 			Context("with service responding 401", func() {
-				It("performs the retry based on the numRetry param", func() {
-					mockResponse := &http.Response{StatusCode: 401}
+				mockResponse := &http.Response{StatusCode: 401}
 
-					handler = func(w http.ResponseWriter, r *http.Request) {
-						resp := map[string]interface{}{
-							"access_token": "abc",
-							"expires_in":   "3600",
-							"scope":        "",
-							"token_type":   "bearer",
-						}
-						exp, _ := json.Marshal(resp)
-						fmt.Fprintf(w, string(exp))
+				handler = func(w http.ResponseWriter, r *http.Request) {
+					resp := map[string]interface{}{
+						"access_token": "abc",
+						"expires_in":   "3600",
+						"scope":        "",
+						"token_type":   "bearer",
 					}
+					exp, _ := json.Marshal(resp)
+					fmt.Fprintf(w, string(exp))
+				}
+				It("performs the retry based on the numRetry param", func() {
 					t1 := time.Now().Unix()
 					resp, _ := client.RequestWithCustomRetry("resource", []string{"scope"}, 1, func(token string) (*http.Response, error) {
 						return mockResponse, nil
 					})
 					t2 := time.Now().Unix()
 					Expect(t2 - t1).To(BeNumerically(">=", 1))
+					Expect(t2 - t1).To(BeNumerically("<", 2))
 					Expect(resp.StatusCode).To(Equal(401))
+				})
 
-					client.MaxRetry = 2
-					t1 = time.Now().Unix()
-					resp, _ = client.RequestWithCustomRetry("resource", []string{"scope"}, 0, func(token string) (*http.Response, error) {
-						return mockResponse, nil
-					})
-					t2 = time.Now().Unix()
-					Expect(t2 - t1).To(BeNumerically("<", 1))
-					Expect(resp.StatusCode).To(Equal(401))
+				Context("and retry count less than 1", func() {
+					It("uses the DefaultRetryCount for the retry", func() {
+						client.DefaultRetryCount = 1
+						t1 := time.Now().Unix()
+						resp, _ := client.RequestWithCustomRetry("resource", []string{"scope"}, 0, func(token string) (*http.Response, error) {
+							return mockResponse, nil
+						})
+						t2 := time.Now().Unix()
+						Expect(t2 - t1).To(BeNumerically(">=", 1))
+						Expect(t2 - t1).To(BeNumerically("<", 2))
+						Expect(resp.StatusCode).To(Equal(401))
 
-					t1 = time.Now().Unix()
-					resp, _ = client.RequestWithCustomRetry("resource", []string{"scope"}, -1, func(token string) (*http.Response, error) {
-						return mockResponse, nil
+						t1 = time.Now().Unix()
+						resp, _ = client.RequestWithCustomRetry("resource", []string{"scope"}, -1, func(token string) (*http.Response, error) {
+							return mockResponse, nil
+						})
+						t2 = time.Now().Unix()
+						Expect(t2 - t1).To(BeNumerically(">=", 1))
+						Expect(t2 - t1).To(BeNumerically("<", 2))
+						Expect(resp.StatusCode).To(Equal(401))
 					})
-					t2 = time.Now().Unix()
-					Expect(t2 - t1).To(BeNumerically(">=", 3))
-					Expect(resp.StatusCode).To(Equal(401))
+
+					It("retries 1 time when DefaultRetryCount is less than 1", func() {
+						client.DefaultRetryCount = 0
+						t1 := time.Now().Unix()
+						resp, _ := client.RequestWithCustomRetry("resource", []string{"scope"}, 0, func(token string) (*http.Response, error) {
+							return mockResponse, nil
+						})
+						t2 := time.Now().Unix()
+						Expect(t2 - t1).To(BeNumerically(">=", 1))
+						Expect(t2 - t1).To(BeNumerically("<", 2))
+						Expect(resp.StatusCode).To(Equal(401))
+					})
 				})
 			})
 
@@ -380,7 +400,7 @@ var _ = Describe("Sand", func() {
 
 				Context("and retry twice", func() {
 					It("should take at least 3 seconds to finish the retry and return error", func() {
-						client.MaxRetry = 2
+						client.DefaultRetryCount = 2
 						t1 := time.Now().Unix()
 						//Retry should sleep two times: 1 + 2 = 3 seconds
 						token, err := client.oauthToken([]string{"scope"}, -1)
@@ -412,6 +432,57 @@ var _ = Describe("Sand", func() {
 
 			Expect(client.cacheKey("hello", []string{"a", "b"}, "")).To(Equal(client.CacheRoot + "/" + client.cacheType + "/hello/a_b"))
 			Expect(client.cacheKey("", []string{"a"}, "")).To(Equal(client.CacheRoot + "/" + client.cacheType + "//a"))
+		})
+	})
+
+	Describe("#clientRequestRetryCount", func() {
+		Context("with positive number of default retry count", func() {
+			It("calculates a valid client request retry count", func() {
+				client.DefaultRetryCount = 3
+				Expect(client.clientRequestRetryCount(2)).To(Equal(2))
+				Expect(client.clientRequestRetryCount(1)).To(Equal(1))
+				Expect(client.clientRequestRetryCount(0)).To(Equal(1))
+				Expect(client.clientRequestRetryCount(-1)).To(Equal(3))
+			})
+		})
+		Context("with default retry count being 0 or less", func() {
+			It("calculates a valid client request retry count", func() {
+				client.DefaultRetryCount = 0
+				Expect(client.clientRequestRetryCount(2)).To(Equal(2))
+				Expect(client.clientRequestRetryCount(1)).To(Equal(1))
+				Expect(client.clientRequestRetryCount(0)).To(Equal(1))
+				Expect(client.clientRequestRetryCount(-1)).To(Equal(1))
+
+				client.DefaultRetryCount = -1
+				Expect(client.clientRequestRetryCount(2)).To(Equal(2))
+				Expect(client.clientRequestRetryCount(1)).To(Equal(1))
+				Expect(client.clientRequestRetryCount(0)).To(Equal(1))
+				Expect(client.clientRequestRetryCount(-1)).To(Equal(1))
+			})
+		})
+	})
+
+	Describe("#tokenRequestRetryCount", func() {
+		Context("with positive number of default retry count", func() {
+			It("calculates a valid token request retry count", func() {
+				client.DefaultRetryCount = 3
+				Expect(client.tokenRequestRetryCount(1)).To(Equal(1))
+				Expect(client.tokenRequestRetryCount(0)).To(Equal(0))
+				Expect(client.tokenRequestRetryCount(-1)).To(Equal(3))
+			})
+		})
+		Context("with default retry count being 0 or less", func() {
+			It("calculates a valid token request retry count", func() {
+				client.DefaultRetryCount = 0
+				Expect(client.tokenRequestRetryCount(1)).To(Equal(1))
+				Expect(client.tokenRequestRetryCount(0)).To(Equal(0))
+				Expect(client.tokenRequestRetryCount(-1)).To(Equal(0))
+
+				client.DefaultRetryCount = -1
+				Expect(client.tokenRequestRetryCount(1)).To(Equal(1))
+				Expect(client.tokenRequestRetryCount(0)).To(Equal(0))
+				Expect(client.tokenRequestRetryCount(-1)).To(Equal(0))
+			})
 		})
 	})
 })

--- a/service.go
+++ b/service.go
@@ -71,11 +71,11 @@ func NewService(id, secret, tokenURL, resource, verifyURL string, scopes []strin
 //    }
 //  }
 func (s *Service) CheckRequest(r *http.Request, targetScopes []string, action string) (map[string]interface{}, error) {
-	return s.CheckRequestWithCustomRetry(r, targetScopes, action, s.MaxRetry)
+	return s.CheckRequestWithCustomRetry(r, targetScopes, action, s.DefaultRetryCount)
 }
 
 //CheckRequestWithCustomRetry allows specifying a positive number as number of retries to
-//use instead of the default MaxRetry on a per-request basis.
+//use instead of using DefaultRetryCount on a per-request basis.
 //Using a negative number for numRetry is equivalent to the "Request" function
 func (s *Service) CheckRequestWithCustomRetry(r *http.Request, targetScopes []string, action string, numRetry int) (map[string]interface{}, error) {
 	token := ExtractToken(r.Header.Get("Authorization"))

--- a/service_test.go
+++ b/service_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Service", func() {
 
 	BeforeEach(func() {
 		service, _ = NewService("i", "s", "u", "r", "/v", []string{"scope"})
-		service.MaxRetry = 0
+		service.DefaultRetryCount = 0
 	})
 
 	Describe("#NewService", func() {


### PR DESCRIPTION
Client to service retry must be at least once in case of the client's token is expired, it must retry to get a new token.

For client/service getting a token from Sand, the retry count can be 0. This is not changed.

The change is the same as sand-ruby's https://github.com/coupa/sand-ruby/pull/15

- [x] @johnny-lai 