### PR TITLE
CD-152760 When authentication server returns 500 on token verificatio…

### DIFF
--- a/sand.go
+++ b/sand.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/coupa/sand-go/cache"
+	log "github.com/sirupsen/logrus"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
@@ -101,7 +102,7 @@ func (c *Client) RequestWithCustomRetry(cacheKey string, scopes []string, numRet
 		//Get a fresh token from authentication service and retry.
 		for retry := 0; resp.StatusCode == http.StatusUnauthorized && retry < clientRetry; retry++ {
 			sleep := time.Duration(math.Pow(2, float64(retry)))
-			logger.Warnf("Sand request: retrying after %d sec on %d", sleep, http.StatusUnauthorized)
+			log.Warnf("Sand request: retrying after %d sec on %d", sleep, http.StatusUnauthorized)
 			time.Sleep(sleep * time.Second)
 			//Prevent reading from cache on retry
 			if c.Cache != nil {
@@ -172,7 +173,7 @@ func (c *Client) oauthToken(scopes []string, numRetry int) (token *oauth2.Token,
 		for retry := 0; err != nil && retry < numRetry; retry++ {
 			//Exponential backoff on the retry
 			sleep := time.Duration(math.Pow(2, float64(retry)))
-			logger.Warnf("Sand token: retrying after %d sec because of error: %v", sleep, err)
+			log.Warnf("Sand token: retrying after %d sec because of error: %v", sleep, err)
 			time.Sleep(sleep * time.Second)
 			token, err = config.Token(ctx)
 		}

--- a/service_test.go
+++ b/service_test.go
@@ -238,8 +238,26 @@ var _ = Describe("Service", func() {
 				})
 			})
 
+			Context("with 500 response when verifying a token", func() {
+				It("returns nil", func() {
+					handler = func(w http.ResponseWriter, r *http.Request) {
+						var resp map[string]interface{}
+						if r.RequestURI == "/" {
+							resp = map[string]interface{}{"access_token": "def"}
+							exp, _ := json.Marshal(resp)
+							fmt.Fprintf(w, string(exp))
+						} else if r.RequestURI == "/v" {
+							w.WriteHeader(http.StatusInternalServerError)
+						}
+					}
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
+					Expect(err).To(BeNil())
+					Expect(t).To(BeNil())
+				})
+			})
+
 			Context("with an invalid json response when verifying token", func() {
-				It("", func() {
+				It("returns an error", func() {
 					handler = func(w http.ResponseWriter, r *http.Request) {
 						var resp map[string]interface{}
 						if r.RequestURI == "/" {

--- a/util.go
+++ b/util.go
@@ -3,12 +3,6 @@ package sand
 import (
 	"strings"
 
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	//logger is used to log detail errors
-	logger = logrus.New()
 )
 
 //ExtractToken extracts a bearer token from the Authorization header.


### PR DESCRIPTION
…n (such as token expired), let the client retry by returning allowed => false instead of an error

As it turned out, when a service verifying an expired token with Sand, the service will get a 500 response from Sand. So in this case, we want to return {allowed: false} and let the client retry, instead of returning an error.

Also on error, append the response body to the error log and message.

- [x] @johnny-lai 