### PR TITLE
Make default cache global to any new client/service created.

### DIFF
--- a/sand_test.go
+++ b/sand_test.go
@@ -18,6 +18,7 @@ var _ = Describe("Sand", func() {
 	var client *Client
 
 	BeforeEach(func() {
+		caches = map[time.Duration]cache.Cache{}
 		client, _ = NewClient("i", "s", "u")
 		client.DefaultRetryCount = 0
 	})
@@ -26,6 +27,26 @@ var _ = Describe("Sand", func() {
 		It("gives error when missing required arguments", func() {
 			_, err := NewClient("", "s", "u")
 			Expect(err.Error()).To(Equal("NewClient: missing required argument(s)"))
+		})
+
+		It("uses the same global cache", func() {
+			c1, err := NewClient("a", "s", "u")
+			Expect(err).To(BeNil())
+
+			c2, err := NewClient("a", "s", "u")
+			Expect(err).To(BeNil())
+			Expect(c1.Cache).To(Equal(caches[defaultExpiryTime]))
+			Expect(c1.Cache).To(Equal(c2.Cache))
+		})
+
+		It("uses the same global cache with custom expiry time", func() {
+			c1, err := NewClientWithExpiration("a", "s", "u", time.Second)
+			Expect(err).To(BeNil())
+
+			c2, err := NewClientWithExpiration("a", "s", "u", time.Second)
+			Expect(err).To(BeNil())
+			Expect(c1.Cache).To(Equal(caches[time.Second]))
+			Expect(c1.Cache).To(Equal(c2.Cache))
 		})
 	})
 

--- a/service_test.go
+++ b/service_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/coupa/sand-go/cache"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -75,6 +76,7 @@ var _ = Describe("Service", func() {
 	var service *Service
 
 	BeforeEach(func() {
+		caches = map[time.Duration]cache.Cache{}
 		service, _ = NewService("i", "s", "u", "r", "/v", []string{"scope"})
 		service.DefaultRetryCount = 0
 	})
@@ -85,6 +87,17 @@ var _ = Describe("Service", func() {
 			Expect(err.Error()).To(Equal("NewService: missing required argument(s)"))
 			_, err = NewService("i", "s", "u", "", "/v", []string{"scope"})
 			Expect(err.Error()).To(Equal("NewService: missing required argument(s)"))
+		})
+
+		It("uses the same global cache", func() {
+			c1, err := NewService("c", "s", "u", "r", "/v", []string{"scope"})
+			Expect(err).To(BeNil())
+
+			c2, err := NewClient("a", "s", "u")
+			Expect(err).To(BeNil())
+
+			Expect(c2.Cache).To(Equal(caches[defaultExpiryTime]))
+			Expect(c1.Cache).To(Equal(c2.Cache))
 		})
 	})
 


### PR DESCRIPTION
Before the default cache is one per new client/service object, which is not nice if an app creates multiple objects because they will have individual caches instead of sharing.

So make the default cache global. If someone wants to have a cache with a different default expiration time, that will create another global cache.

- [x] @johnny-lai 