### PR TITLE
Remove skip tls verify option and add option to minimum version of SS…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A client that intends to communicate with a service can use sand.Client to reque
 client := sand.NewClient("ClientID", "ClientSecret", "TokenURL")
 
 //Below shows the optional fields (with their default values) that can be modified after a client is created
-client.SkipTLSVerify = false   // Skip verifying the TLS certificate
+client.SSLMinVersion = tls.VersionTLS12 // Minimum version of SSL supported
 client.MaxRetry      = 5       // Maximum number of retries on connection error
 client.Cache         = nil     // A cache that conforms to the sand.Cache interface
 client.CacheRoot     = "sand"  // A string as the root namespace in the cache

--- a/sand.go
+++ b/sand.go
@@ -33,9 +33,8 @@ type Client struct {
 	//TokenURL: The token endpoint of the OAuth2 server, e.g., "https://oauth.example.com/oauth2/token"
 	TokenURL string
 
-	//SkipTLSVerify skips checking the SSL certificate. Should be false for production.
-	//Default is false
-	SkipTLSVerify bool
+	//SSLMinVersion is the minimum supported TLS version. Default is TLS 1.2.
+	SSLMinVersion uint16
 
 	//DefaultRetryCount is the default number of retries to perform with exponential backoff when
 	//1. Clients receive 401 response from services
@@ -88,7 +87,7 @@ func NewClientWithCache(id, secret, tokenURL string, cache cache.Cache) (client 
 		ClientID:          id,
 		ClientSecret:      secret,
 		TokenURL:          tokenURL,
-		SkipTLSVerify:     false,
+		SSLMinVersion:     tls.VersionTLS12,
 		DefaultRetryCount: 5,
 		Cache:             cache,
 		CacheRoot:         "sand",
@@ -201,7 +200,7 @@ func (c *Client) OAuth2TokenWithoutCaching(scopes []string, numRetry int) (token
 	numRetry = c.tokenRequestRetryCount(numRetry)
 
 	client := &http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: c.SkipTLSVerify},
+		TLSClientConfig: &tls.Config{MinVersion: c.SSLMinVersion},
 	}}
 	ctx := context.TODO()
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, client)

--- a/service.go
+++ b/service.go
@@ -42,7 +42,7 @@ type Service struct {
 	Scopes []string
 }
 
-// VerificationOption ...
+// VerificationOption affects how tokens are verified
 type VerificationOption struct {
 	TargetScopes []string
 	Resource     string
@@ -91,7 +91,7 @@ func (s *Service) CheckRequestWithCustomRetry(r *http.Request, targetScopes []st
 	return s.VerifyRequest(r, VerificationOption{TargetScopes: targetScopes, Action: action, NumRetry: &numRetry})
 }
 
-//VerifyRequest ...
+//VerifyRequest takes the token in a request and verifies with SAND
 //Remember to set a reasonable NumRetry value (>= 0) for the VerificationOption
 func (s *Service) VerifyRequest(r *http.Request, opt VerificationOption) (map[string]interface{}, error) {
 	token := ExtractToken(r.Header.Get("Authorization"))

--- a/service.go
+++ b/service.go
@@ -199,7 +199,7 @@ func (s *Service) verifyToken(token string, opt VerificationOption) (map[string]
 	req.Header.Add("Authorization", "Bearer "+accessToken)
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, AuthenticationError{err.Error()}
 	}
 
 	defer resp.Body.Close()

--- a/service.go
+++ b/service.go
@@ -95,12 +95,7 @@ func (s *Service) CheckRequestWithCustomRetry(r *http.Request, targetScopes []st
 //Remember to set a reasonable NumRetry value (>= 0) for the VerificationOption
 func (s *Service) VerifyRequest(r *http.Request, opt VerificationOption) (map[string]interface{}, error) {
 	token := ExtractToken(r.Header.Get("Authorization"))
-	rv, err := s.VerifyTokenWithCache(token, opt)
-	if err != nil {
-		log.Error(err)
-		err = AuthenticationError{"Service failed to verify the token: " + err.Error()}
-	}
-	return rv, err
+	return s.VerifyTokenWithCache(token, opt)
 }
 
 //ErrorCode gets the HTTP error code based on the error type. By default it is
@@ -199,7 +194,7 @@ func (s *Service) verifyToken(token string, opt VerificationOption) (map[string]
 	req.Header.Add("Authorization", "Bearer "+accessToken)
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, AuthenticationError{err.Error()}
+		return nil, AuthenticationError{"Service failed to verify the token: " + err.Error()}
 	}
 
 	defer resp.Body.Close()

--- a/service.go
+++ b/service.go
@@ -42,6 +42,7 @@ type Service struct {
 	Scopes []string
 }
 
+// VerificationOption ...
 type VerificationOption struct {
 	TargetScopes []string
 	Resource     string
@@ -90,7 +91,7 @@ func (s *Service) CheckRequestWithCustomRetry(r *http.Request, targetScopes []st
 	return s.VerifyRequest(r, VerificationOption{TargetScopes: targetScopes, Action: action, NumRetry: &numRetry})
 }
 
-//VerifyRequest
+//VerifyRequest ...
 //Remember to set a reasonable NumRetry value (>= 0) for the VerificationOption
 func (s *Service) VerifyRequest(r *http.Request, opt VerificationOption) (map[string]interface{}, error) {
 	token := ExtractToken(r.Header.Get("Authorization"))

--- a/service.go
+++ b/service.go
@@ -95,7 +95,11 @@ func (s *Service) CheckRequestWithCustomRetry(r *http.Request, targetScopes []st
 //Remember to set a reasonable NumRetry value (>= 0) for the VerificationOption
 func (s *Service) VerifyRequest(r *http.Request, opt VerificationOption) (map[string]interface{}, error) {
 	token := ExtractToken(r.Header.Get("Authorization"))
-	return s.VerifyTokenWithCache(token, opt)
+	rv, err := s.VerifyTokenWithCache(token, opt)
+	if err != nil {
+		log.Error(err)
+	}
+	return rv, err
 }
 
 //ErrorCode gets the HTTP error code based on the error type. By default it is

--- a/service.go
+++ b/service.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
-	"fmt"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -183,7 +183,7 @@ func (s *Service) verifyToken(token string, opt VerificationOption) (map[string]
 		return nil, err
 	}
 	client := &http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: s.SkipTLSVerify},
+		TLSClientConfig: &tls.Config{MinVersion: s.SSLMinVersion},
 	}}
 	data := map[string]interface{}{
 		"scopes":   opt.TargetScopes,

--- a/service_test.go
+++ b/service_test.go
@@ -1,6 +1,7 @@
 package sand
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -312,11 +313,21 @@ var _ = Describe("Service", func() {
 				})
 			})
 
-			// these are the tests that require the proxy environment setup in BeforeSuite and AfterSuite
 			Context("with a proxy blocking the request", func() {
 				It("returns an error getting token", func() {
 					service.TokenURL = "http://sand.test"
 					service.TokenVerifyURL = service.TokenURL + "/v"
+					handler = func(w http.ResponseWriter, r *http.Request) {
+						var resp map[string]interface{}
+						if r.RequestURI == "/" {
+							resp = map[string]interface{}{"access_token": "def"}
+						} else if r.RequestURI == "/v" {
+							Expect(r.Header.Get("Authorization")).To(Equal("Bearer def"))
+							resp = map[string]interface{}{"allowed": true}
+						}
+						exp, _ := json.Marshal(resp)
+						fmt.Fprintf(w, string(exp))
+					}
 					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
 					Expect(t).To(BeNil())
 					Expect(err).To(MatchError(AuthenticationError{Message: "oauth2: cannot fetch token: 403 Forbidden\nResponse: "}))
@@ -338,6 +349,66 @@ var _ = Describe("Service", func() {
 					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
 					Expect(t).To(BeNil())
 					Expect(err).To(MatchError(AuthenticationError{Message: "Error response from the authentication service: 403 - "}))
+				})
+			})
+
+			Context("with a TLS server whose version is too old", func() {
+				var (
+					ss *httptest.Server
+				)
+				BeforeEach(func() {
+					ss = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						handler(w, r)
+					}))
+					ss.TLS = &tls.Config{
+						MaxVersion: tls.VersionTLS11,
+					}
+					ss.StartTLS()
+				})
+				AfterEach(func() {
+					ss.Close()
+				})
+
+				It("returns an error getting token", func() {
+					service.TokenURL = ss.URL
+					service.TokenVerifyURL = service.TokenURL + "/v"
+					handler = func(w http.ResponseWriter, r *http.Request) {
+						var resp map[string]interface{}
+						if r.RequestURI == "/" {
+							resp = map[string]interface{}{"access_token": "def"}
+						} else if r.RequestURI == "/v" {
+							Expect(r.Header.Get("Authorization")).To(Equal("Bearer def"))
+							resp = map[string]interface{}{"allowed": true}
+						}
+						exp, _ := json.Marshal(resp)
+						fmt.Fprintf(w, string(exp))
+					}
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
+					Expect(t).To(BeNil())
+					Expect(err).To(MatchError(AuthenticationError{
+						Message: fmt.Sprintf("Post \"%s\": remote error: tls: protocol version not supported", service.TokenURL),
+					}))
+				})
+
+				It("returns an error verifying token", func() {
+					service.TokenVerifyURL = ss.URL + "/v"
+					handler = func(w http.ResponseWriter, r *http.Request) {
+						var resp map[string]interface{}
+						if r.RequestURI == "/" {
+							resp = map[string]interface{}{"access_token": "def"}
+						} else if r.RequestURI == "/v" {
+							Expect(r.Header.Get("Authorization")).To(Equal("Bearer def"))
+							resp = map[string]interface{}{"allowed": true}
+						}
+						exp, _ := json.Marshal(resp)
+						fmt.Fprintf(w, string(exp))
+					}
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
+					Expect(t).To(BeNil())
+					Expect(err).To(MatchError(AuthenticationError{
+						Message: fmt.Sprintf("Post \"%s\": remote error: tls: protocol version not supported", service.TokenVerifyURL),
+					}))
 				})
 			})
 		})

--- a/service_test.go
+++ b/service_test.go
@@ -235,10 +235,10 @@ var _ = Describe("Service", func() {
 		})
 
 		Describe("#verifyToken", func() {
-			minus_one := -1
+			minusOne := -1
 			Context("with empty token", func() {
 				It("returns nil", func() {
-					t, err := service.verifyToken("", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
+					t, err := service.verifyToken("", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
 					Expect(t).To(BeNil())
 					Expect(err).To(BeNil())
 				})
@@ -249,7 +249,7 @@ var _ = Describe("Service", func() {
 					handler = func(w http.ResponseWriter, r *http.Request) {
 						w.WriteHeader(http.StatusNotFound)
 					}
-					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
 					Expect(t).To(BeNil())
 					_, yes := err.(AuthenticationError)
 					Expect(yes).To(BeTrue())
@@ -269,7 +269,7 @@ var _ = Describe("Service", func() {
 						exp, _ := json.Marshal(resp)
 						fmt.Fprintf(w, string(exp))
 					}
-					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
 					Expect(err).To(BeNil())
 					Expect(t).To(Equal(map[string]interface{}{"allowed": true}))
 				})
@@ -287,7 +287,7 @@ var _ = Describe("Service", func() {
 							w.WriteHeader(http.StatusInternalServerError)
 						}
 					}
-					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
 					Expect(err).To(BeNil())
 					Expect(t).To(BeNil())
 				})
@@ -306,7 +306,7 @@ var _ = Describe("Service", func() {
 							fmt.Fprintf(w, "bad")
 						}
 					}
-					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
 					Expect(err).NotTo(BeNil())
 					Expect(t).To(BeNil())
 				})
@@ -317,7 +317,7 @@ var _ = Describe("Service", func() {
 				It("returns an error getting token", func() {
 					service.TokenURL = "http://sand.test"
 					service.TokenVerifyURL = service.TokenURL + "/v"
-					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
 					Expect(t).To(BeNil())
 					Expect(err).To(MatchError(AuthenticationError{Message: "oauth2: cannot fetch token: 403 Forbidden\nResponse: "}))
 				})
@@ -335,7 +335,7 @@ var _ = Describe("Service", func() {
 						exp, _ := json.Marshal(resp)
 						fmt.Fprintf(w, string(exp))
 					}
-					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
 					Expect(t).To(BeNil())
 					Expect(err).To(MatchError(AuthenticationError{Message: "Error response from the authentication service: 403 - "}))
 				})

--- a/service_test.go
+++ b/service_test.go
@@ -355,7 +355,7 @@ var _ = Describe("Service", func() {
 					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minusOne})
 					Expect(t).To(BeNil())
 					Expect(err).To(MatchError(AuthenticationError{
-						Message: fmt.Sprintf("Post \"%s\": remote error: tls: protocol version not supported", service.TokenVerifyURL),
+						Message: fmt.Sprintf("Service failed to verify the token: Post \"%s\": remote error: tls: protocol version not supported", service.TokenVerifyURL),
 					}))
 				})
 			})


### PR DESCRIPTION
…L supported

OPS is requiring TLS 1.2. So add the option to set the minimum version of SSL.

Remove the option to skip TLS verify, which was for development purpose in the past.

- [x] @johnny-lai 