### PR TITLE
Clone default transport for sane defaults

### DIFF
--- a/sand.go
+++ b/sand.go
@@ -1,7 +1,6 @@
 package sand
 
 import (
-	"crypto/tls"
 	"errors"
 	"math"
 	"net/http"
@@ -200,9 +199,9 @@ func (c *Client) OAuth2Token(cacheKey string, scopes []string, numRetry int) (*o
 func (c *Client) OAuth2TokenWithoutCaching(scopes []string, numRetry int) (token *oauth2.Token, err error) {
 	numRetry = c.tokenRequestRetryCount(numRetry)
 
-	client := &http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: c.SkipTLSVerify},
-	}}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig.InsecureSkipVerify = c.SkipTLSVerify
+	client := &http.Client{Transport: transport}
 	ctx := context.TODO()
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
 

--- a/sand.go
+++ b/sand.go
@@ -202,6 +202,7 @@ func (c *Client) OAuth2TokenWithoutCaching(scopes []string, numRetry int) (token
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig.InsecureSkipVerify = c.SkipTLSVerify
 	client := &http.Client{Transport: transport}
+
 	ctx := context.TODO()
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
 

--- a/service.go
+++ b/service.go
@@ -2,10 +2,9 @@ package sand
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
-	"fmt"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -182,9 +181,9 @@ func (s *Service) verifyToken(token string, opt VerificationOption) (map[string]
 	if err != nil {
 		return nil, err
 	}
-	client := &http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: s.SkipTLSVerify},
-	}}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig.InsecureSkipVerify = s.SkipTLSVerify
+	client := &http.Client{Transport: transport}
 	data := map[string]interface{}{
 		"scopes":   opt.TargetScopes,
 		"token":    token,

--- a/service.go
+++ b/service.go
@@ -181,9 +181,11 @@ func (s *Service) verifyToken(token string, opt VerificationOption) (map[string]
 	if err != nil {
 		return nil, err
 	}
+
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig.InsecureSkipVerify = s.SkipTLSVerify
 	client := &http.Client{Transport: transport}
+
 	data := map[string]interface{}{
 		"scopes":   opt.TargetScopes,
 		"token":    token,

--- a/service_test.go
+++ b/service_test.go
@@ -312,6 +312,7 @@ var _ = Describe("Service", func() {
 				})
 			})
 
+			// these are the tests that require the proxy environment setup in BeforeSuite and AfterSuite
 			Context("with a proxy blocking the request", func() {
 				It("returns an error getting token", func() {
 					service.TokenURL = "http://sand.test"

--- a/service_test.go
+++ b/service_test.go
@@ -5,11 +5,18 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"time"
 
 	"github.com/coupa/sand-go/cache"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+)
+
+var (
+	oldProxy    string
+	oldProxySet bool
+	ps          *httptest.Server
 )
 
 func ItBehavesLikeVerifyTokenWithCache(handler *func(http.ResponseWriter, *http.Request), subject func(string, []string, string, int) (map[string]interface{}, error)) {
@@ -71,6 +78,23 @@ func ItBehavesLikeVerifyTokenWithCache(handler *func(http.ResponseWriter, *http.
 		})
 	})
 }
+
+var _ = BeforeSuite(func() {
+	oldProxy, oldProxySet = os.LookupEnv("HTTP_PROXY")
+	ps = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	os.Setenv("HTTP_PROXY", ps.URL)
+})
+
+var _ = AfterSuite(func() {
+	if oldProxySet {
+		os.Setenv("HTTP_PROXY", oldProxy)
+	} else {
+		os.Unsetenv("HTTP_PROXY")
+	}
+	ps.Close()
+})
 
 var _ = Describe("Service", func() {
 	var service *Service
@@ -285,6 +309,34 @@ var _ = Describe("Service", func() {
 					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
 					Expect(err).NotTo(BeNil())
 					Expect(t).To(BeNil())
+				})
+			})
+
+			Context("with a proxy blocking the request", func() {
+				It("returns an error getting token", func() {
+					service.TokenURL = "http://sand.test"
+					service.TokenVerifyURL = service.TokenURL + "/v"
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
+					Expect(t).To(BeNil())
+					Expect(err).To(MatchError(AuthenticationError{Message: "oauth2: cannot fetch token: 403 Forbidden\nResponse: "}))
+				})
+
+				It("returns an error verifying token", func() {
+					service.TokenVerifyURL = "http://sand.test/v"
+					handler = func(w http.ResponseWriter, r *http.Request) {
+						var resp map[string]interface{}
+						if r.RequestURI == "/" {
+							resp = map[string]interface{}{"access_token": "def"}
+						} else if r.RequestURI == "/v" {
+							Expect(r.Header.Get("Authorization")).To(Equal("Bearer def"))
+							resp = map[string]interface{}{"allowed": true}
+						}
+						exp, _ := json.Marshal(resp)
+						fmt.Fprintf(w, string(exp))
+					}
+					t, err := service.verifyToken("abc", VerificationOption{TargetScopes: []string{"scope"}, Action: "", Resource: "resource", Context: nil, NumRetry: &minus_one})
+					Expect(t).To(BeNil())
+					Expect(err).To(MatchError(AuthenticationError{Message: "Error response from the authentication service: 403 - "}))
 				})
 			})
 		})


### PR DESCRIPTION
### Problem
In order to customize TLS client configuration, `verifyToken` and `OAuth2Token` create new `http.Client`s with new `http.Transport`s. However, creating a `http.Transport` with only the relevant field set leaves all the other fields as their 0 values, which means it does not read the environment for proxy settings and has no timeouts, among other sane defaults that the default `Transport` has.

### Solution
Instead of creating a new `Transport` with just the relevant flags, create one by cloning the `http.DefaultTransport`, which has sane defaults for all the fields, then override the values that we care about before use.

### Test caveat
In order to test the proxy environment is being read, we have to set it in the test suite. However, the `Proxy` function in `http.DefaultTransport` memoizes the environment values the first time it runs, so we are not able to set it temporarily during this particular test. Fortunately, that function always returns no proxy when the request is for localhost, which is the case for all the other test cases, so everything still works with the proxy environment set.

- [x] @johnwu96822 